### PR TITLE
Make 'make dev' install dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: init dev
 init:
 	pipenv install --dev
 
-dev:
+dev: init
 	pipenv run watchmedo auto-restart \
 		--patterns="*.py" \
 		--recursive \


### PR DESCRIPTION
No makefile magic is done to only install if needed, since
pipenv takes care of that part.