### PR TITLE
Asset transfer

### DIFF
--- a/resources/dev_opus.yaml
+++ b/resources/dev_opus.yaml
@@ -53,6 +53,6 @@ assets:
   "script":
     path: "script.pdf"
   "audio_sample":
-    path: "res/sample.mp3"
+    path: "audio/sample.mp3"
   "seagull":
     path: "video/seagull.mp4"

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,7 @@ class Core:
     async def main(self):
         """The main loop."""
         opus_file = os.environ.get("OPUS", "dev_opus.yaml")
+        print("Loading opus...")
         self._opus = await load_opus(Path("resources") / opus_file)
         self._performance = Performance(self._opus)
         self._ui = UI(self._opus, self._performance.history)
@@ -39,6 +40,7 @@ class Core:
         }
         self._setup_events()
 
+        print("Started!")
         async with websockets.serve(self.socket_listener, "localhost", self._port):
             await asyncio.Future()  # run forever
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,13 @@
 import asyncio
 import json
+from typing import Dict
 import os
 from pathlib import Path
 import websockets
 from websockets.server import WebSocketServerProtocol
 
 from opus import ActionTemplate, load_opus
+from peers.component import ComponentPeer
 from performance import Performance
 from peers.audio import Audio
 from peers.internal import InternalPeer
@@ -33,12 +35,13 @@ class Core:
         self._opus = await load_opus(Path("resources") / opus_file)
         self._performance = Performance(self._opus)
         self._ui = UI(self._opus, self._performance.history)
-        self._components = {
+        self._components: Dict[str,ComponentPeer] = {
             "internal": InternalPeer(),
             "screen": Screen(),
             "audio": Audio()
         }
         self._setup_events()
+        self._distribute_assets()
 
         print("Started!")
         async with websockets.serve(self.socket_listener, "localhost", self._port):
@@ -54,6 +57,12 @@ class Core:
             component.add_event_listener("effect-added", self._ui.effect_added)
             component.add_event_listener("effect-changed", self._ui.effect_changed)
             component.add_event_listener("effect-removed", self._ui.effect_removed)
+    
+    def _distribute_assets(self):
+        for asset in self._opus.assets.values():
+            for component in self._components.values():
+                if any([component.handles_target(target) for target in asset.targets]):
+                    component.add_asset(asset)
     
     def _run_action_by_id(self, action_id):
         try:

--- a/src/opus.py
+++ b/src/opus.py
@@ -1,13 +1,18 @@
+import asyncio
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+import hashlib
+from typing import Any, Dict, List
 from pathlib import Path
 import aiofiles
 import yaml
 
 @dataclass
 class Asset:
-    """An asset describes a resource file"""
+    """An asset contains a resource"""
     path: str
+    data: bytes
+    checksum: str
+    targets: List[str]
 
 
 @dataclass
@@ -46,8 +51,11 @@ async def load_opus(opus_path: Path):
     async with aiofiles.open(opus_path, mode="r", encoding="utf-8") as f:
         opus_string = await f.read()
         opus_dict = yaml.safe_load(opus_string)
-        assets = {key: Asset(**asset) for key, asset in opus_dict["assets"].items()}
         action_templates = {key: ActionTemplate(id=key, **action) for key, action in opus_dict["action_templates"].items()}
+        assets = dict(await asyncio.gather(
+            *[load_asset(key, asset["path"], action_templates, opus_path)
+              for key, asset in opus_dict["assets"].items()]
+        ))
         nodes = {key: Node(**node) for key, node in opus_dict["nodes"].items()}
         start_node = opus_dict["startNode"]
 
@@ -57,3 +65,28 @@ async def load_opus(opus_path: Path):
         script = await f.read()
 
     return Opus(nodes, action_templates, assets, start_node, script)
+
+async def load_asset(key: str, path: str, action_templates: Dict[str, ActionTemplate], opus_path: Path):
+    """
+    Load an asset from a file.
+    
+    Parameters
+    ----------
+    key
+        The ID of the asset. Used for checking where it is used.
+    path
+        The path to the file, relative to the opus path
+    action_templates
+        All action templates in the opus. Used for checking where the asset is used.
+    opus_path
+        The path to the opus file
+    
+    Returns
+    -------
+    A list of tuples (key, asset)
+    """
+    targets = set(action.target for action in action_templates.values() if key in action.assets)
+    async with aiofiles.open(opus_path.parent / path, mode="rb") as f:
+        data = await f.read()
+    checksum=hashlib.md5(data).hexdigest()
+    return (key, Asset(path=path, data=data, checksum=checksum, targets=targets))

--- a/src/peers/component.py
+++ b/src/peers/component.py
@@ -22,6 +22,10 @@ class ComponentPeer(EventEmitter):
         super().__init__()
         self._target_types = target_types
         self._websockets: List[WebSocketServerProtocol] = []
+        self._assets: List[Asset] = []
+    
+    def add_asset(self, asset: Asset):
+        self._assets.append(asset)
 
     async def handle_socket(self, websocket: WebSocketServerProtocol):
         """This handles one websocket connection."""

--- a/src/peers/component.py
+++ b/src/peers/component.py
@@ -1,3 +1,4 @@
+import base64
 import json
 import traceback
 from typing import Any, List, Dict
@@ -30,6 +31,9 @@ class ComponentPeer(EventEmitter):
     async def handle_socket(self, websocket: WebSocketServerProtocol):
         """This handles one websocket connection."""
         self._websockets.append(websocket)
+        for asset in self._assets:
+            await websocket.send(json.dumps({"command": "file", "path": asset.path, 
+            "data": base64.b64encode(asset.data).decode("utf-8")}))
         # Handle messages from the client
         async for message in websocket:
             try:


### PR DESCRIPTION
Core now sends 'file' messages, containing assets that shall be written do the components' 'resources' directory.

Files are base64-encoded and sent in a single websocket message. This currently does not handle long videos well, which will be fixed later.