### PR TITLE
Find line locations in the PDF if not specified

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ watchdog = "2.1.6"
 websockets = "10.0"
 aiofiles = "0.8.0"
 pyyaml = "6.0"
+pymupdf = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b32447424d352292ced488cd48833ee8797df4e9c96a4aa119fe658c45bed757"
+            "sha256": "f06b624fc98e80a03eb4fe826eba06246080f69f08f62f67edc6925746c74b85"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,31 @@
             ],
             "index": "pypi",
             "version": "==0.8.0"
+        },
+        "pymupdf": {
+            "hashes": [
+                "sha256:03878ff8bb343516e9580930c233105e0a69bbeaebddcb3dcc281ffb8c0944ca",
+                "sha256:125783986da87fe1a5372d621e90fa49e454454af0b3d0f894858c146c712f81",
+                "sha256:17f1b8ff934d02ffc3dfb6af4ce0d1545a722eff180aa675e17ff7ac40b731f9",
+                "sha256:196cfb75eb17271b62f59eacc769710e55c5a4277c455520851db0db9c3b381b",
+                "sha256:42c9188e39ee33b207a810d1f9ff635a8247d9e64b8af432ef36b9696763f8eb",
+                "sha256:4e19dfb82d247027757fb75d5fb73d8ce430930a0c7d2f492913aefd1875345c",
+                "sha256:5046b479a44c55423df0c746cd4d858bd244c85cdfaf46e7fd4298ba7f586365",
+                "sha256:5b347655a948c6a9d2d66a0d1e651f9888ce6e2915ee6a2e60498a0c735b5330",
+                "sha256:65647d992bcc77b52d808c40a08b6b98a6012371ffef9c764a34bb0580b3abcf",
+                "sha256:656a7bec93bc89feabb4c34d3c7c8ef18335837870a2ae4b4bcb91eff9d6ce10",
+                "sha256:6ee61379f001f7bc892afefae886d07d49320d9641eeeb40dcc936903addeb4d",
+                "sha256:910d4159698adcd7783a5fcde17079bb295abc2d3d604ccb8ed257a24b4e7dbf",
+                "sha256:9abd78c614455d0695fbcff693a85cc906b8fcbaa24fb576182b20a87db2eddd",
+                "sha256:aca2f2f94bda157a0365230fe11dcf1b9f6ab592943cc7534d92389f1058cd86",
+                "sha256:b33c5a68a4bcfe8f948127aad61f25e172d6851993235f46cc395b2038c2eb84",
+                "sha256:c126efda315be900ecf194b3d04b93cc211db8fa6c3b31af482d6c5aac2c5b66",
+                "sha256:c9ee5f4f413ac3675835426ee182aa7c68774c11ce9f9f61f65f7f34d810ce38",
+                "sha256:eeccac87ab19127ef6f15caa3b12fdf02e944864816844b456b5856582056873",
+                "sha256:f140acdecdc3a6cbc6987eda3f1df9a5c8d85b0c1044f4132fde4813acbd905a"
+            ],
+            "index": "pypi",
+            "version": "==1.19.4"
         },
         "pyyaml": {
             "hashes": [

--- a/resources/dev_opus.yaml
+++ b/resources/dev_opus.yaml
@@ -9,42 +9,28 @@ nodes:
       - node: "1396"
         description: "Medkännande"
     prompt: "Jag har hört att han är dömd att segla de sju haven för alltid i en fruktlös jakt på sin älskade!"
-    pdfPage: 2
-    pdfLocationOnPage: 0.6
     actions: ["run_short_video"]
   "160":
     next: "1126"
     prompt: "Ja, då var vi av med honom!"
-    pdfPage: 8
-    pdfLocationOnPage: 0.4
     actions: ["stop_thorin_song", "add_example_image"]
   "1663":
     next: "1126"
     prompt: "Jag är paff!"
-    pdfPage: 69
-    pdfLocationOnPage: 0.55
   "1396":
     next: "1126"
     prompt: "Jag beklagar. Jag hör att du höll av honom."
-    pdfPage: 59
-    pdfLocationOnPage: 0.71
   "1126":
     next: "415"
     prompt: "Vad är tårtan till?"
-    pdfPage: 48
-    pdfLocationOnPage: 0.48
     actions: []
   "415":
     next: "459"
     prompt: "Ah, inte illa. Vad sa du att du hette?"
-    pdfPage: 21
-    pdfLocationOnPage: 0.3
     actions: ["add_inventory", "play_thorin_song", "volume_thorin_song"]
   "459":
     next: "11"
     prompt: "Carla..."
-    pdfPage: 22
-    pdfLocationOnPage: 0.5
     actions: ["run_long_video", "print_test"]
 action_templates:
   "play_thorin_song":

--- a/src/opus.py
+++ b/src/opus.py
@@ -3,8 +3,14 @@ from dataclasses import dataclass, field
 import hashlib
 from typing import Any, Dict, List, Optional, Union
 from pathlib import Path
+import re
 import aiofiles
+import fitz
 import yaml
+
+LEFT_PAGE_LINE_NUMBER_END = (76, 77)
+RIGHT_PAGE_LINE_NUMBER_END = (62, 63)
+
 
 @dataclass
 class Asset:
@@ -29,6 +35,13 @@ class NodeChoice:
     """One choice of node when the opus branches"""
     node: str
     description: str
+
+@dataclass
+class NodeChoice:
+    """One choice of node when the opus branches"""
+    node: str
+    description: str
+
 
 @dataclass
 class Node:
@@ -56,30 +69,28 @@ async def load_opus(opus_path: Path):
     async with aiofiles.open(opus_path, mode="r", encoding="utf-8") as f:
         opus_string = await f.read()
         opus_dict = yaml.safe_load(opus_string)
-        action_templates = {key: ActionTemplate(id=key, **action) for key, action in opus_dict["action_templates"].items()}
+        action_templates = {key: ActionTemplate(
+            id=key, **action) for key, action in opus_dict["action_templates"].items()}
         assets = dict(await asyncio.gather(
             *[load_asset(key, asset["path"], action_templates, opus_path)
               for key, asset in opus_dict["assets"].items()]
         ))
-        nodes = {}
-        for key, node in opus_dict["nodes"].items():
-            typed_node = node.copy()
-            if isinstance(typed_node.get("next"), list):
-                typed_node["next"] = [NodeChoice(**node_choice) for node_choice in node["next"]]
-            nodes[key] = Node(**typed_node)
+        if assets.get("script") is None:
+            raise RuntimeError(
+                "Warning: Asset 'script' not found. This is required.")
+        nodes = await load_nodes(opus_dict["nodes"], parent / assets["script"].path)
         start_node = opus_dict["startNode"]
 
-    if assets.get("script") is None:
-        raise RuntimeError("Warning: Asset 'script' not found. This is required.")
     async with aiofiles.open(parent / assets["script"].path, mode="rb") as f:
         script = await f.read()
 
     return Opus(nodes, action_templates, assets, start_node, script)
 
+
 async def load_asset(key: str, path: str, action_templates: Dict[str, ActionTemplate], opus_path: Path):
     """
     Load an asset from a file.
-    
+
     Parameters
     ----------
     key
@@ -90,16 +101,86 @@ async def load_asset(key: str, path: str, action_templates: Dict[str, ActionTemp
         All action templates in the opus. Used for checking where the asset is used.
     opus_path
         The path to the opus file
-    
+
     Returns
     -------
     A list of tuples (key, asset)
     """
-    targets = set(action.target for action in action_templates.values() if key in action.assets)
+    targets = set(
+        action.target for action in action_templates.values() if key in action.assets)
     data = None
     checksum = None
     if not path.startswith("http://") and not path.startswith("https://"):
         async with aiofiles.open(opus_path.parent / path, mode="rb") as f:
             data = await f.read()
-        checksum=hashlib.md5(data).hexdigest()
+        checksum = hashlib.md5(data).hexdigest()
     return (key, Asset(path=path, data=data, checksum=checksum, targets=targets))
+
+
+async def load_nodes(nodes_dict: Dict[str, Any], script_path: Path) -> Dict[str, Node]:
+    """
+    Load the nodes, and find their locations on the page.
+
+    If a node does not already have defined pdfPage and pdfLocationOnPage,
+    we will try to find it in the PDF. If so, we assume the node ID begins
+    with the line number, e.g. "12" or "13a".
+
+    Parameters
+    ----------
+    nodes_dict
+        The nodes from the opus file
+    script_path
+        Path to the script PDF
+
+    Returns
+    -------
+    The nodes
+    """
+    doc = fitz.open(script_path)
+    # Get all node keys where we need to discover the location.
+    node_keys = [
+        key for key, value in nodes_dict.items()
+        if "pdfPage" not in value or "pdfLocationOnPage" not in value
+    ]
+    try:
+        with_line_numbers = [(key, re.match(r"[0-9]+", key).group(0))
+                             for key in node_keys]
+    except AttributeError:
+        raise RuntimeError(
+            "Nodes without specified PDF locations must have IDs beginning with numbers. "
+            f"Offenders: {[key for key in node_keys if re.match(r'[0-9]+', key) is None]}"
+        )
+    sorted_keys_and_numbers = sorted(
+        with_line_numbers, key=lambda x: int(x[1]))
+    next_pair = sorted_keys_and_numbers.pop(0)
+    # Searching for e.g. "12" will find both "12" and "112". Since the wanted line numbers
+    # are sorted, the first occurrence we find is correct.
+    for page in doc:
+        while True:
+            key, line_number = next_pair
+            found = [
+                rect for rect in page.search_for(line_number)
+                if (LEFT_PAGE_LINE_NUMBER_END[0] < rect.x1 < LEFT_PAGE_LINE_NUMBER_END[1])
+                or (RIGHT_PAGE_LINE_NUMBER_END[0] < rect.x1 < RIGHT_PAGE_LINE_NUMBER_END[1])
+            ]
+            if len(found) == 0:
+                # We won't find anything more on this page, since the wanted line numbers are sorted
+                break
+            nodes_dict[key]["pdfPage"] = page.number
+            y = (found[0].y0 + found[0].y1) / 2
+            nodes_dict[key]["pdfLocationOnPage"] = y / page.rect.y1
+            if len(sorted_keys_and_numbers) == 0:
+                next_pair = None
+                break
+            next_pair = sorted_keys_and_numbers.pop(0)
+        if next_pair is None:
+            break
+
+    nodes = {}
+    for key, node in nodes_dict.items():
+        typed_node = node.copy()
+        if isinstance(typed_node.get("next"), list):
+            typed_node["next"] = [NodeChoice(
+                **node_choice) for node_choice in node["next"]]
+        nodes[key] = Node(**typed_node)
+    return nodes

--- a/src/opus.py
+++ b/src/opus.py
@@ -8,6 +8,8 @@ import aiofiles
 import fitz
 import yaml
 
+# TODO: Autodiscover these instead of hard-coding them, in case
+# the script looks different in the future.
 LEFT_PAGE_LINE_NUMBER_END = (76, 77)
 RIGHT_PAGE_LINE_NUMBER_END = (62, 63)
 


### PR DESCRIPTION
This is done based on the node ID, in the interest of not
making the opus file too verbose.