### PR TITLE
Allow inlined actions and assets

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -77,7 +77,7 @@ class Core:
             return
 
     def _run_action_on_the_fly(self, target, cmd, asset_names, params):
-        action = ActionTemplate(1337, target, cmd, asset_names, params)
+        action = ActionTemplate("on_the_fly_action", target, cmd, asset_names, params)
         assets = [self._opus.assets[name] for name in asset_names]
         self._run_action(action, assets)
 

--- a/src/opus.py
+++ b/src/opus.py
@@ -32,12 +32,14 @@ class ActionTemplate:
     assets: List[str] = field(default_factory=list)
     params: Dict[str, Any] = field(default_factory=dict)
 
+
 @dataclass
 class NodeChoice:
     """One choice of node when the opus branches"""
     node: str
     description: str
     actions: List[str] = field(default_factory=list)
+
 
 @dataclass
 class Node:
@@ -66,7 +68,8 @@ async def load_opus(opus_path: Path):
         opus_string = await f.read()
         opus_dict = yaml.safe_load(opus_string)
         nodes, inlined_action_dicts = await load_nodes(opus_dict["nodes"], parent / opus_dict["assets"]["script"]["path"])
-        action_templates, inlined_asset_dicts = load_actions({**opus_dict["action_templates"], **inlined_action_dicts})
+        action_templates, inlined_asset_dicts = load_actions(
+            {**opus_dict["action_templates"], **inlined_action_dicts})
         assets = dict(await asyncio.gather(
             *[load_asset(key, asset["path"], action_templates, opus_path)
               for key, asset in [*opus_dict["assets"].items(), *inlined_asset_dicts.items()]]
@@ -111,6 +114,7 @@ async def load_asset(key: str, path: str, action_templates: Dict[str, ActionTemp
         checksum = hashlib.md5(data).hexdigest()
     return (key, Asset(path=path, data=data, checksum=checksum, targets=targets))
 
+
 def load_actions(action_dicts: Dict[str, dict]) -> Tuple[Dict[str, ActionTemplate], Dict[str, dict]]:
     """
     Load actions, and pick out inlined assets.
@@ -119,7 +123,7 @@ def load_actions(action_dicts: Dict[str, dict]) -> Tuple[Dict[str, ActionTemplat
     ----------
     action_dicts
         Dict of actions, as found in the opus
-    
+
     Returns
     -------
     Dict of actions, converted to ActionTemplates, and a dict of inlined assets
@@ -128,14 +132,15 @@ def load_actions(action_dicts: Dict[str, dict]) -> Tuple[Dict[str, ActionTemplat
     assets = {}
     for key, action_dict in action_dicts.items():
         typed_action_dict = action_dict.copy()
-        for i, asset in enumerate(typed_action_dict["assets"]):
-            if isinstance(asset, dict):
-                asset_id = f"{key}_asset_{i}"
-                assets[asset_id] = asset
-                typed_action_dict["assets"][i] = asset_id
+        if "assets" in typed_action_dict:
+            for i, asset in enumerate(typed_action_dict["assets"]):
+                if isinstance(asset, dict):
+                    asset_id = f"{key}_asset_{i}"
+                    assets[asset_id] = asset
+                    typed_action_dict["assets"][i] = asset_id
         actions[key] = ActionTemplate(id=key, **typed_action_dict)
     return actions, assets
-    
+
 
 async def load_nodes(nodes_dict: Dict[str, dict], script_path: Path) -> Tuple[Dict[str, Node], Dict[str, dict]]:
     """
@@ -165,7 +170,7 @@ async def load_nodes(nodes_dict: Dict[str, dict], script_path: Path) -> Tuple[Di
     if len(node_keys) > 0:
         try:
             with_line_numbers = [(key, re.match(r"[0-9]+", key).group(0))
-                                for key in node_keys]
+                                 for key in node_keys]
         except AttributeError:
             raise RuntimeError(
                 "Nodes without specified PDF locations must have IDs beginning with numbers. "
@@ -196,7 +201,7 @@ async def load_nodes(nodes_dict: Dict[str, dict], script_path: Path) -> Tuple[Di
                 next_pair = sorted_keys_and_numbers.pop(0)
             if next_pair is None:
                 break
-    
+
     # Convert nodes from dicts to Node objects, and pick out all inlined actions.
     # We make up action IDs.
     nodes = {}
@@ -205,13 +210,14 @@ async def load_nodes(nodes_dict: Dict[str, dict], script_path: Path) -> Tuple[Di
         typed_node = node.copy()
         if isinstance(typed_node.get("next"), list):
             for i, choice in enumerate(typed_node["next"]):
-                if isinstance(choice.get("actions"), list):
+                if "actions" in choice:
                     for j, action in enumerate(choice["actions"]):
-                        action_id = f"{key}_choice_{i}_action_{j}"
-                        action_dicts[action_id] = action
-                        choice["actions"][j] = action_id
+                        if isinstance(action, dict):
+                            action_id = f"{key}_choice_{i}_action_{j}"
+                            action_dicts[action_id] = action
+                            choice["actions"][j] = action_id
                 typed_node["next"][i] = NodeChoice(**choice)
-        if isinstance(typed_node.get("actions"), list):
+        if "actions" in typed_node:
             for i, action in enumerate(typed_node["actions"]):
                 if isinstance(action, dict):
                     action_id = f"{key}_action_{i}"

--- a/src/opus.py
+++ b/src/opus.py
@@ -1,7 +1,7 @@
 import asyncio
 from dataclasses import dataclass, field
 import hashlib
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from pathlib import Path
 import re
 import aiofiles
@@ -26,7 +26,7 @@ class Asset:
 @dataclass
 class ActionTemplate:
     """An Action is a command triggered by a node"""
-    id: int
+    id: str
     target: str
     cmd: str
     assets: List[str] = field(default_factory=list)
@@ -65,16 +65,15 @@ async def load_opus(opus_path: Path):
     async with aiofiles.open(opus_path, mode="r", encoding="utf-8") as f:
         opus_string = await f.read()
         opus_dict = yaml.safe_load(opus_string)
-        action_templates = {key: ActionTemplate(
-            id=key, **action) for key, action in opus_dict["action_templates"].items()}
+        nodes, inlined_action_dicts = await load_nodes(opus_dict["nodes"], parent / opus_dict["assets"]["script"]["path"])
+        action_templates, inlined_asset_dicts = load_actions({**opus_dict["action_templates"], **inlined_action_dicts})
         assets = dict(await asyncio.gather(
             *[load_asset(key, asset["path"], action_templates, opus_path)
-              for key, asset in opus_dict["assets"].items()]
+              for key, asset in [*opus_dict["assets"].items(), *inlined_asset_dicts.items()]]
         ))
         if assets.get("script") is None:
             raise RuntimeError(
                 "Warning: Asset 'script' not found. This is required.")
-        nodes = await load_nodes(opus_dict["nodes"], parent / assets["script"].path)
         start_node = opus_dict["startNode"]
 
     async with aiofiles.open(parent / assets["script"].path, mode="rb") as f:
@@ -112,10 +111,35 @@ async def load_asset(key: str, path: str, action_templates: Dict[str, ActionTemp
         checksum = hashlib.md5(data).hexdigest()
     return (key, Asset(path=path, data=data, checksum=checksum, targets=targets))
 
-
-async def load_nodes(nodes_dict: Dict[str, Any], script_path: Path) -> Dict[str, Node]:
+def load_actions(action_dicts: Dict[str, dict]) -> Tuple[Dict[str, ActionTemplate], Dict[str, dict]]:
     """
-    Load the nodes, and find their locations on the page.
+    Load actions, and pick out inlined assets.
+
+    Parameters
+    ----------
+    action_dicts
+        Dict of actions, as found in the opus
+    
+    Returns
+    -------
+    Dict of actions, converted to ActionTemplates, and a dict of inlined assets
+    """
+    actions = {}
+    assets = {}
+    for key, action_dict in action_dicts.items():
+        typed_action_dict = action_dict.copy()
+        for i, asset in enumerate(typed_action_dict["assets"]):
+            if isinstance(asset, dict):
+                asset_id = f"{key}_asset_{i}"
+                assets[asset_id] = asset
+                typed_action_dict["assets"][i] = asset_id
+        actions[key] = ActionTemplate(id=key, **typed_action_dict)
+    return actions, assets
+    
+
+async def load_nodes(nodes_dict: Dict[str, dict], script_path: Path) -> Tuple[Dict[str, Node], Dict[str, dict]]:
+    """
+    Load the nodes, find their locations on the page, and pick out inlined actions.
 
     If a node does not already have defined pdfPage and pdfLocationOnPage,
     we will try to find it in the PDF. If so, we assume the node ID begins
@@ -130,7 +154,7 @@ async def load_nodes(nodes_dict: Dict[str, Any], script_path: Path) -> Dict[str,
 
     Returns
     -------
-    The nodes
+    The nodes and the inlined actions
     """
     doc = fitz.open(script_path)
     # Get all node keys where we need to discover the location.
@@ -173,11 +197,26 @@ async def load_nodes(nodes_dict: Dict[str, Any], script_path: Path) -> Dict[str,
             if next_pair is None:
                 break
     
+    # Convert nodes from dicts to Node objects, and pick out all inlined actions.
+    # We make up action IDs.
     nodes = {}
+    action_dicts = {}
     for key, node in nodes_dict.items():
         typed_node = node.copy()
         if isinstance(typed_node.get("next"), list):
-            typed_node["next"] = [NodeChoice(
-                **node_choice) for node_choice in node["next"]]
+            for i, choice in enumerate(typed_node["next"]):
+                if isinstance(choice.get("actions"), list):
+                    for j, action in enumerate(choice["actions"]):
+                        action_id = f"{key}_choice_{i}_action_{j}"
+                        action_dicts[action_id] = action
+                        choice["actions"][j] = action_id
+                typed_node["next"][i] = NodeChoice(**choice)
+        if isinstance(typed_node.get("actions"), list):
+            for i, action in enumerate(typed_node["actions"]):
+                if isinstance(action, dict):
+                    action_id = f"{key}_action_{i}"
+                    action_dicts[action_id] = action
+                    typed_node["actions"][i] = action_id
         nodes[key] = Node(**typed_node)
-    return nodes
+
+    return nodes, action_dicts

--- a/util/commands/audio.schema.json
+++ b/util/commands/audio.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://kulturkrock.se/audiocommand.schema.json",
+    "$id": "https://kulturkrock.se/commands/audio.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Audio commands in Opus",
     "description": "An audio command in an Opus to use for Screencrash",
@@ -43,8 +43,13 @@
                     "description": "Asset to play. This command expects exactly ONE asset",
                     "type": "array",
                     "items": {
-                        "title": "Asset ID",
-                        "type": "string"
+                        "oneOf":[
+                            {
+                                "title": "Asset ID",
+                                "type": "string"
+                            },
+                            {"$ref": "../asset.schema.json#"}
+                        ]
                     },
                     "minLength": 1,
                     "maxLength": 1

--- a/util/commands/image.schema.json
+++ b/util/commands/image.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://kulturkrock.se/imagecommand.schema.json",
+    "$id": "https://kulturkrock.se/commands/image.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Image commands in Opus",
     "description": "An image command in an Opus to use for Screencrash",
@@ -43,8 +43,13 @@
                     "description": "Asset to show. This command expects exactly ONE asset",
                     "type": "array",
                     "items": {
-                        "title": "Asset ID",
-                        "type": "string"
+                        "oneOf":[
+                            {
+                                "title": "Asset ID",
+                                "type": "string"
+                            },
+                            {"$ref": "../asset.schema.json#"}
+                        ]
                     },
                     "minLength": 1,
                     "maxLength": 1

--- a/util/commands/internal.schema.json
+++ b/util/commands/internal.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://kulturkrock.se/internalcommand.schema.json",
+    "$id": "https://kulturkrock.se/commands/internal.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Internal commands in Opus",
     "description": "An internal command in an Opus to use for Screencrash",

--- a/util/commands/video.schema.json
+++ b/util/commands/video.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://kulturkrock.se/videocommand.schema.json",
+    "$id": "https://kulturkrock.se/commands/video.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Video commands in Opus",
     "description": "A video command in an Opus to use for Screencrash",
@@ -43,8 +43,13 @@
                     "description": "Asset to play. This command expects exactly ONE asset",
                     "type": "array",
                     "items": {
-                        "title": "Asset ID",
-                        "type": "string"
+                        "oneOf":[
+                            {
+                                "title": "Asset ID",
+                                "type": "string"
+                            },
+                            {"$ref": "../asset.schema.json#"}
+                        ]
                     },
                     "minLength": 1,
                     "maxLength": 1

--- a/util/commands/web.schema.json
+++ b/util/commands/web.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://kulturkrock.se/webcommand.schema.json",
+    "$id": "https://kulturkrock.se/commands/web.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Web commands in Opus",
     "description": "A web command in an Opus to use for Screencrash",
@@ -43,8 +43,13 @@
                     "description": "Asset to show. This command expects exactly ONE asset",
                     "type": "array",
                     "items": {
-                        "title": "Asset ID",
-                        "type": "string"
+                        "oneOf":[
+                            {
+                                "title": "Asset ID",
+                                "type": "string"
+                            },
+                            {"$ref": "../asset.schema.json#"}
+                        ]
                     },
                     "minLength": 1,
                     "maxLength": 1

--- a/util/node.schema.json
+++ b/util/node.schema.json
@@ -36,8 +36,13 @@
                                 "description": "The actions which should run when performing this choice",
                                 "type": "array",
                                 "items": {
-                                    "title": "Action ID",
-                                    "type": "string"
+                                    "oneOf": [
+                                        {
+                                            "title": "Action ID",
+                                            "type": "string"
+                                        },
+                                        {"$ref": "action.schema.json#"}
+                                    ]
                                 }
                             }
                         },
@@ -68,8 +73,13 @@
             "description": "The actions on this node",
             "type": "array",
             "items": {
-                "title": "Action ID",
-                "type": "string"
+                "oneOf": [
+                    {
+                        "title": "Action ID",
+                        "type": "string"
+                    },
+                    {"$ref": "action.schema.json#"}
+                ]
             }
         }
     },


### PR DESCRIPTION
This may prove to be more convenient when reading/writing an opus.
Let's allow both inlined and separate and try it out.