### PR TITLE
Validate references at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ The following commands are available:
 
 You can configure Core with the following environment variables:
 
-| Variable                  | Effect                                          |
-| ------------------------- | ----------------------------------------------- | --------------- |
-| `OPUS`                    | Which opus file (under `resources`) to use      | `dev_opus.yaml` |
-| `SCREENCRASH_SYNC_ASSETS` | Whether to sync assets when components connect. | `true`          |
+| Variable                                 | Effect                                          |                 |
+| ---------------------------------------- | ----------------------------------------------- | --------------- |
+| `OPUS`                                   | Which opus file (under `resources`) to use      | `dev_opus.yaml` |
+| `SCREENCRASH_SYNC_ASSETS`                | Whether to sync assets when components connect. | `true`          |
+| `SCREENCRASH_EXIT_ON_VALIDATION_FAILURE` | Whether to exit if the opus fails to validate   | `true`          |
 
 ## Files and Folders
 

--- a/src/main.py
+++ b/src/main.py
@@ -33,8 +33,14 @@ class Core:
         opus_file = os.environ.get("OPUS", "dev_opus.yaml")
         sync_assets = os.environ.get(
             "SCREENCRASH_SYNC_ASSETS", "true") == "true"
+        exit_on_validation_failure = os.environ.get(
+            "SCREENCRASH_EXIT_ON_VALIDATION_FAILURE", "true") == "true"
         print("Loading opus...")
-        self._opus = await load_opus(Path("resources") / opus_file, read_asset_data=sync_assets)
+        self._opus = await load_opus(
+            Path("resources") / opus_file,
+            read_asset_data=sync_assets,
+            exit_on_validation_failure=exit_on_validation_failure
+        )
         self._performance = Performance(self._opus)
         self._ui = UI(self._opus, self._performance.history)
         self._components: Dict[str, ComponentPeer] = {

--- a/src/opus.py
+++ b/src/opus.py
@@ -4,6 +4,7 @@ import hashlib
 from typing import Any, Dict, List, Optional, Tuple, Union
 from pathlib import Path
 import re
+import sys
 import aiofiles
 import fitz
 import yaml
@@ -83,7 +84,9 @@ async def load_opus(opus_path: Path, read_asset_data: bool):
     async with aiofiles.open(parent / assets["script"].path, mode="rb") as f:
         script = await f.read()
 
-    return Opus(nodes, action_templates, assets, start_node, script)
+    opus = Opus(nodes, action_templates, assets, start_node, script)
+    validate_references(opus)
+    return opus
 
 
 async def load_asset(key: str, path: str, action_templates: Dict[str, ActionTemplate], opus_path: Path, read_asset_data: bool):
@@ -229,3 +232,75 @@ async def load_nodes(nodes_dict: Dict[str, dict], script_path: Path) -> Tuple[Di
         nodes[key] = Node(**typed_node)
 
     return nodes, action_dicts
+
+
+def validate_references(opus: Opus):
+    """
+    Validate that we only refer to existing nodes, assets and actions.
+
+    Exits the program if validation fails.
+
+    Parameters
+    ----------
+    opus
+        The opus
+    """
+    # Nodes
+    referred_nodes = set([opus.start_node])
+    for node in opus.nodes.values():
+        if isinstance(node.next, str):
+            referred_nodes.add(node.next)
+        elif isinstance(node.next, list):
+            for choice in node.next:
+                referred_nodes.add(choice.node)
+    actual_nodes = set(opus.nodes.keys())
+    if referred_nodes != actual_nodes:
+        nonexistent_nodes = referred_nodes - actual_nodes
+        unreferred_nodes = actual_nodes - referred_nodes
+        print("Malformed opus!")
+        if nonexistent_nodes:
+            print("References to nonexistent nodes:")
+            print('\n'.join(nonexistent_nodes))
+        if unreferred_nodes:
+            print("Nodes never referred to:")
+            print('\n'.join(unreferred_nodes))
+        sys.exit(1)
+
+    # Assets
+    referred_assets = set(["script"])
+    for action in opus.action_templates.values():
+        referred_assets.update(set(action.assets))
+    actual_assets = set(opus.assets.keys())
+    if referred_assets != actual_assets:
+        nonexistent_assets = referred_assets - actual_assets
+        unreferred_assets = actual_assets - referred_assets
+        print("Malformed opus!")
+        if nonexistent_assets:
+            print("References to nonexistent assets:")
+            print('\n'.join(nonexistent_assets))
+        if unreferred_assets:
+            print("Assets never referred to:")
+            print('\n'.join(unreferred_assets))
+        sys.exit(1)
+
+    # Actions
+    referred_actions = set()
+    for node in opus.nodes.values():
+        if node.actions is not None:
+            referred_actions.update(set(node.actions))
+        if isinstance(node.next, list):
+            for choice in node.next:
+                if choice.actions is not None:
+                    referred_actions.update(set(choice.actions))
+    actual_actions = set(opus.action_templates.keys())
+    if referred_actions != actual_actions:
+        nonexistent_actions = referred_actions - actual_actions
+        unreferred_actions = actual_actions - referred_actions
+        print("Malformed opus!")
+        if nonexistent_actions:
+            print("References to nonexistent actions:")
+            print('\n'.join(nonexistent_actions))
+        if unreferred_actions:
+            print("Actions never referred to:")
+            print('\n'.join(unreferred_actions))
+        sys.exit(1)

--- a/src/opus.py
+++ b/src/opus.py
@@ -63,7 +63,7 @@ class Opus:
     script: bytes
 
 
-async def load_opus(opus_path: Path, read_asset_data: bool):
+async def load_opus(opus_path: Path, read_asset_data: bool, exit_on_validation_failure: bool):
     """Load an opus from a file."""
     parent = opus_path.parent
     async with aiofiles.open(opus_path, mode="r", encoding="utf-8") as f:
@@ -85,7 +85,7 @@ async def load_opus(opus_path: Path, read_asset_data: bool):
         script = await f.read()
 
     opus = Opus(nodes, action_templates, assets, start_node, script)
-    validate_references(opus)
+    validate_references(opus, exit_on_validation_failure)
     return opus
 
 
@@ -234,7 +234,7 @@ async def load_nodes(nodes_dict: Dict[str, dict], script_path: Path) -> Tuple[Di
     return nodes, action_dicts
 
 
-def validate_references(opus: Opus):
+def validate_references(opus: Opus, exit_on_failure: bool):
     """
     Validate that we only refer to existing nodes, assets and actions.
 
@@ -244,6 +244,8 @@ def validate_references(opus: Opus):
     ----------
     opus
         The opus
+    exit_on_failure
+        Whether to exit the program if validation fails
     """
     # Nodes
     referred_nodes = set([opus.start_node])
@@ -264,7 +266,9 @@ def validate_references(opus: Opus):
         if unreferred_nodes:
             print("Nodes never referred to:")
             print('\n'.join(unreferred_nodes))
-        sys.exit(1)
+        if exit_on_failure:
+            print("Aborting!")
+            sys.exit(1)
 
     # Assets
     referred_assets = set(["script"])
@@ -281,7 +285,9 @@ def validate_references(opus: Opus):
         if unreferred_assets:
             print("Assets never referred to:")
             print('\n'.join(unreferred_assets))
-        sys.exit(1)
+        if exit_on_failure:
+            print("Aborting!")
+            sys.exit(1)
 
     # Actions
     referred_actions = set()
@@ -303,4 +309,6 @@ def validate_references(opus: Opus):
         if unreferred_actions:
             print("Actions never referred to:")
             print('\n'.join(unreferred_actions))
-        sys.exit(1)
+        if exit_on_failure:
+            print("Aborting!")
+            sys.exit(1)


### PR DESCRIPTION
Screencrash now validates all references in the opus at startup,
and crashes if there are problems.